### PR TITLE
Added support for the default option in the field definition

### DIFF
--- a/lib/datafile.js
+++ b/lib/datafile.js
@@ -501,7 +501,7 @@ _.extend(Writer.prototype, {
                     self._resetBlocks();
                     if (final) {
                         self.emit('end');
-                        process.nextTick(function() {
+                        setImmediate(function() {
                             self.destroy();
                         });
                     }
@@ -511,7 +511,7 @@ _.extend(Writer.prototype, {
         } else {
         	if (final) {
         		self.emit('end');
-                process.nextTick(function() {
+                setImmediate(function() {
                     self.destroy();
                 });
         	}
@@ -545,7 +545,7 @@ _.extend(Writer.prototype, {
     end: function(data) {
         var self = this;
         if (this._paused) {
-            process.nextTick(function() {
+            setImmediate(function() {
                 self.end(data);
             });
         } else {

--- a/lib/io.js
+++ b/lib/io.js
@@ -576,7 +576,11 @@ DatumWriter.prototype = {
         var self = this;
         _.each(writersSchema.fields, function(field) {
             try {
-                self.writeData(field.type, datum[field.name], encoder);
+                if ( datum[field.name] === undefined ) {
+                  self.writeData(field.type, field.default, encoder);
+                } else {
+                  self.writeData(field.type, datum[field.name], encoder);
+                }
             } catch (err) {
                 if (err.fieldPath) {
                     err.fieldPath.unshift(field.name);

--- a/lib/io.js
+++ b/lib/io.js
@@ -558,7 +558,10 @@ DatumWriter.prototype = {
             } else if (writersSchema.schemas[i].type === 'array' && writersSchema.schemas[i].validate(writersSchema.schemas[i].type, datum)) {
                 schemaIndex = i;
                 break;
-            } else if (writersSchema.isPrimitive(writersSchema.schemas[i].type) && writersSchema.validate(writersSchema.schemas[i].type, datum)) {
+            } else if (writersSchema.isPrimitive(writersSchema.schemas[i].type) && writersSchema.validate(writersSchema.schemas[i].type, datum)) {              
+                schemaIndex = i;
+                break;
+            } else if (writersSchema.schemas[i].type === 'map' && writersSchema.schemas[i].validate(writersSchema.schemas[i].type, datum)) {
                 schemaIndex = i;
                 break;
             }

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -80,7 +80,7 @@ _.extend(Schema.prototype, {
                 } else {
                     return new RecordSchema(schema.name, schema.namespace,
                                             _.map(schema.fields, function(field) {
-                                                return new FieldSchema(field.name, self.parse(field, namespace));
+                                                return new FieldSchema(field.name, self.parse(field, namespace), field.default );
                                             }));
                 }
             } else if (schema.type === 'enum') {
@@ -224,7 +224,7 @@ function PrimitiveSchema(type) {
 
 util.inherits(PrimitiveSchema, Schema);
 
-function FieldSchema(name, type) {
+function FieldSchema(name, type, defaultValue) {
     if (!_.isString(name)) {
         throw new AvroErrors.InvalidSchemaError('Field name must be string');
     }
@@ -235,6 +235,7 @@ function FieldSchema(name, type) {
 
     this.name = name;
     this.type = type;
+    this.default = defaultValue;
 }
 
 //util.inherits(FieldSchema, Schema);

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -169,8 +169,10 @@ _.extend(Schema.prototype, {
                 var fields = _.pluck(this.fields, 'name');
                 var dFields = _.keys(datum);
                 var intersect = _.intersection(fields, dFields);
-                if (intersect.length < dFields.length)
-                    throw new AvroErrors.DataValidationError("Data [%j] has extra fields not in schema. data fields [%j]. schema fields [%j]", datum, dFields, fields);
+                if (intersect.length < dFields.length) {
+                  var diffFields = _.difference( dFields, fields );                  
+                  throw new AvroErrors.DataValidationError("Data [%j] has extra fields not in schema. Extra data fields [%j]", datum, diffFields );
+                }
                 break;
             default:
                 break;

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -184,6 +184,10 @@ _.extend(Schema.prototype, {
                   throw new AvroErrors.DataValidationError("Data [%j] has extra fields not in schema. Extra data fields [%j]", datum, diffFields );
                 }
                 break;
+            case 'map': 
+              if ( _.isNull( datum ) || _.isArray( datum ) || _.isFunction( datum ) || !_.isObject( datum ) ) 
+                throw new AvroErrors.DataValidationError("Data [%j] not a an object", datum, this.symbols);
+              break;                
             default:
                 break;
         }
@@ -194,11 +198,10 @@ _.extend(Schema.prototype, {
     validate: function(schema, datum){
         var self = this;
         try {
-            self.validateAndThrow(schema, datum);
+            return self.validateAndThrow(schema, datum);
         } catch (validateErr) {
             return false;
         }
-        return true;
     },
 
     isPrimitive: function(schema){

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -80,7 +80,7 @@ _.extend(Schema.prototype, {
                 } else {
                     return new RecordSchema(schema.name, schema.namespace,
                                             _.map(schema.fields, function(field) {
-                                                return new FieldSchema(field.name, self.parse(field, namespace), field.default );
+                                                return new FieldSchema(field.name, self.parse(field, namespace), field.default);
                                             }));
                 }
             } else if (schema.type === 'enum') {
@@ -92,14 +92,14 @@ _.extend(Schema.prototype, {
                 }
             } else if (schema.type === 'array') {
                 if (_.has(schema, 'items')) {
-                    return new ArraySchema(this.parse(schema.items, namespace), namespace);
+                    return new ArraySchema(this.parse(schema.items, namespace), namespace, schema.default);
                 } else {
                     throw new AvroErrors.InvalidSchemaError('array must specify "items", got %s',
                                                      JSON.stringify(schema));
                 }
             } else if (schema.type === 'map') {
                 if (_.has(schema, 'values')) {
-                    return new MapSchema(this.parse(schema.values, namespace));
+                    return new MapSchema(this.parse(schema.values, namespace), schema.default);
                 } else {
                     throw new AvroErrors.InvalidSchemaError('map must specify "values" schema, got %s',
                                                      JSON.stringify(schema));
@@ -123,7 +123,7 @@ _.extend(Schema.prototype, {
             var branchTypes = _.map(schema, function(type) {
                 return self.parse(type, schema, namespace);
             });
-            return new UnionSchema(branchTypes, namespace);
+            return new UnionSchema(branchTypes, namespace, schema.default);
         } else {
             throw new AvroErrors.InvalidSchemaError('unexpected Javascript type for schema: ' + (typeof schema));
         }
@@ -270,25 +270,27 @@ function RecordSchema(name, namespace, fields) {
 
 util.inherits(RecordSchema, Schema);
 
-function MapSchema(type) {
+function MapSchema(type, defaultValue) {
     this.type = 'map';
     this.values = type;
+    this.default = defaultValue;
 }
 
 util.inherits(MapSchema, Schema);
 
-function ArraySchema(items) {
+function ArraySchema(items, defaultValue) {
     if (_.isNull(items) || _.isUndefined(items)) {
         throw new AvroErrors.InvalidSchemaError('Array "items" schema should not be null or undefined');
     }
 
     this.type = 'array';
     this.items = items;
+    this.default = defaultValue;
 }
 
 util.inherits(ArraySchema, Schema);
 
-function UnionSchema(schemas, namespace) {
+function UnionSchema(schemas, namespace, defaultValue) {
     if (!_.isArray(schemas) || _.isEmpty(schemas)) {
         throw new InvalidSchemaError('Union must have at least 1 branch');
     }
@@ -296,11 +298,12 @@ function UnionSchema(schemas, namespace) {
     this.type = 'union';
     this.schemas = schemas; //_.map(schemas, function(type) { return makeFullyQualifiedTypeName(type, namespace); });
     this.namespace = namespace;
+    this.default = defaultValue;
 }
 
 util.inherits(UnionSchema, Schema);
 
-function EnumSchema(symbols) {
+function EnumSchema(symbols, defaultValue) {
     if (!_.isArray(symbols)) {
         throw new AvroErrors.InvalidSchemaError('Enum must have array of symbols, got %s',
                                          JSON.stringify(symbols));
@@ -312,15 +315,17 @@ function EnumSchema(symbols) {
 
     this.type = 'enum';
     this.symbols = symbols;
+    this.default = defaultValue;
 }
 
 util.inherits(EnumSchema, Schema);
 
-function FixedSchema(name, size) {
+function FixedSchema(name, size, defaultValue) {
 
     this.type = 'fixed';
     this.name = name;
     this.size = size;
+    this.default = defaultValue;
 }
 
 util.inherits(FixedSchema, Schema);

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -111,6 +111,16 @@ _.extend(Schema.prototype, {
                     throw new AvroErrors.InvalidSchemaError('fixed must specify "size", got %s',
                                                          JSON.stringify(schema));
                 }
+            } else if ( _.isArray( schema.type ) ) {
+                if (_.isEmpty(schema.type)) {
+                    throw new AvroErrors.InvalidSchemaError('unions must have at least 1 branch');
+                }
+                var schemaTypes = _.clone( schema.type );
+                var branchTypes = _.map(schemaTypes, function(type) {
+                    schema.type = type;
+                    return self.parse( schema, namespace);
+                });
+                return new UnionSchema(branchTypes, namespace, schema.default);
             } else if (_.has(schema, 'type')) {
                 return this.parse(schema.type, namespace);
             } else {
@@ -121,7 +131,7 @@ _.extend(Schema.prototype, {
                 throw new AvroErrors.InvalidSchemaError('unions must have at least 1 branch');
             }
             var branchTypes = _.map(schema, function(type) {
-                return self.parse(type, schema, namespace);
+                return self.parse( type, namespace);
             });
             return new UnionSchema(branchTypes, namespace, schema.default);
         } else {
@@ -240,7 +250,7 @@ function FieldSchema(name, type, defaultValue) {
     this.default = defaultValue;
 }
 
-//util.inherits(FieldSchema, Schema);
+util.inherits(FieldSchema, Schema);
 
 function NamedSchema(name, namespace) {
 

--- a/test/io.test.js
+++ b/test/io.test.js
@@ -458,6 +458,24 @@ describe('IO', function(){
                 writer.write(record, encoder);
                 block.toBuffer().toString().should.equal("\u0002\u0006abc");
             });
+            it('should encode a record as the values of its fields in the order of declaration', function(){
+                var schema = Avro.Schema({
+                    "type" : "record",
+                    "name" : "IntStringRecord",
+                    "fields" : [ { "name" : "intField", "type" : "int", "default": 1 },
+                                 { "name" : "longField", "type" : "long", "default" : 2 },
+                                 { "name" : "floatField", "type" : "float", "default" : 3.0 },
+                                 { "name" : "doubleField", "type" : "double", "default" : 4.0 },
+                                 { "name" : "stringField", "type" : "string", "default" : "abc" }]
+                });
+                var block = DataFile.Block();
+                var writer = IO.DatumWriter(schema);
+                var encoder = IO.BinaryEncoder(block);
+                var record = {};
+                
+                writer.write(record, encoder);
+                block.toBuffer().toString().should.equal("\u0002\u0004\u0000\u0000@@\u0000\u0000\u0000\u0000\u0000\u0000\u0010@\u0006abc");
+            });
             it('should encode a union as a long of the zero-based schema position, followed by the value according to the schema at that position', function(){
                 var schema = Avro.Schema([
                     "int",


### PR DESCRIPTION
As the original fork does not seem to be maintained and you worked on it recently figured I would send the patch to you, if you are interested.   I added "default" support in "fields".    Needed support for this when serializing messages with missing data. 
